### PR TITLE
Arithmetic Shift Fix

### DIFF
--- a/rezasm-source/rezasm-core/src/instructions/implementation/arithmetic_instructions.rs
+++ b/rezasm-source/rezasm-core/src/instructions/implementation/arithmetic_instructions.rs
@@ -13,7 +13,6 @@ use crate::util::raw_data::RawData;
 use crate::util::word_size::WordSize;
 
 lazy_static! {
-
     pub static ref ADD: Instruction =
         instruction!(add, |simulator: Simulator,
                            output: InputOutputTarget,
@@ -24,7 +23,6 @@ lazy_static! {
             let k = value1 + value2;
             return output.set(simulator, RawData::from_int(k, simulator.get_word_size()));
         });
-
     pub static ref SUB: Instruction =
         instruction!(sub, |simulator: Simulator,
                            output: InputOutputTarget,
@@ -35,7 +33,6 @@ lazy_static! {
             let k = value1 - value2;
             return output.set(simulator, RawData::from_int(k, simulator.get_word_size()));
         });
-
     pub static ref MUL: Instruction =
         instruction!(mul, |simulator: Simulator,
                            output: InputOutputTarget,
@@ -46,7 +43,6 @@ lazy_static! {
             let k = value1 * value2;
             return output.set(simulator, RawData::from_int(k, simulator.get_word_size()));
         });
-
     pub static ref DIV: Instruction =
         instruction!(div, |simulator: Simulator,
                            output: InputOutputTarget,
@@ -61,7 +57,6 @@ lazy_static! {
                 return output.set(simulator, RawData::from_int(k, simulator.get_word_size()));
             }
         });
-
     pub static ref AND: Instruction =
         instruction!(and, |simulator: Simulator,
                            output: InputOutputTarget,
@@ -72,18 +67,16 @@ lazy_static! {
             let k = value1 & value2;
             return output.set(simulator, RawData::from_int(k, simulator.get_word_size()));
         });
-
     pub static ref OR: Instruction =
         instruction!(or, |simulator: Simulator,
-                           output: InputOutputTarget,
-                           input1: InputTarget,
-                           input2: InputTarget| {
+                          output: InputOutputTarget,
+                          input1: InputTarget,
+                          input2: InputTarget| {
             let value1 = input1.get(&simulator)?.int_value();
             let value2 = input2.get(&simulator)?.int_value();
             let k = value1 | value2;
             return output.set(simulator, RawData::from_int(k, simulator.get_word_size()));
         });
-
     pub static ref XOR: Instruction =
         instruction!(xor, |simulator: Simulator,
                            output: InputOutputTarget,
@@ -94,21 +87,19 @@ lazy_static! {
             let k = value1 ^ value2;
             return output.set(simulator, RawData::from_int(k, simulator.get_word_size()));
         });
-
     pub static ref NOT: Instruction =
         instruction!(not, |simulator: Simulator,
                            output: InputOutputTarget,
                            input1: InputTarget| {
-                let value1 = input1.get(&simulator)?.int_value();
-                let k = !value1;
+            let value1 = input1.get(&simulator)?.int_value();
+            let k = !value1;
             return output.set(simulator, RawData::from_int(k, simulator.get_word_size()));
         });
-
     pub static ref MOD: Instruction =
         instruction!(_mod, |simulator: Simulator,
-                           output: InputOutputTarget,
-                           input1: InputTarget,
-                           input2: InputTarget| {
+                            output: InputOutputTarget,
+                            input1: InputTarget,
+                            input2: InputTarget| {
             let value1 = input1.get(&simulator)?.int_value();
             let value2 = input2.get(&simulator)?.int_value();
             if value2 == 0 {
@@ -118,7 +109,6 @@ lazy_static! {
                 return output.set(simulator, RawData::from_int(k, simulator.get_word_size()));
             }
         });
-
     pub static ref SLL: Instruction =
         instruction!(sll, |simulator: Simulator,
                            output: InputOutputTarget,
@@ -133,10 +123,9 @@ lazy_static! {
             } else {
                 value << shift
             };
-            
+
             return output.set(simulator, RawData::from_int(k, word_size));
         });
-
     pub static ref SRL: Instruction =
         instruction!(srl, |simulator: Simulator,
                            output: InputOutputTarget,
@@ -158,7 +147,6 @@ lazy_static! {
 
             return output.set(simulator, RawData::from_int(k, word_size));
         });
-
     pub static ref SRA: Instruction =
         instruction!(sra, |simulator: Simulator,
                            output: InputOutputTarget,
@@ -176,23 +164,18 @@ lazy_static! {
 
             return output.set(simulator, RawData::from_int(k, word_size));
         });
-
     pub static ref INC: Instruction =
-        instruction!(inc, |simulator: Simulator,
-                           output: InputOutputTarget| {
+        instruction!(inc, |simulator: Simulator, output: InputOutputTarget| {
             let value = output.get(&simulator)?.int_value();
             let k = value + 1;
             return output.set(simulator, RawData::from_int(k, simulator.get_word_size()));
         });
-
     pub static ref DEC: Instruction =
-        instruction!(dec, |simulator: Simulator,
-                           output: InputOutputTarget| {
+        instruction!(dec, |simulator: Simulator, output: InputOutputTarget| {
             let value = output.get(&simulator)?.int_value();
             let k = value - 1;
             return output.set(simulator, RawData::from_int(k, simulator.get_word_size()));
         });
-
 }
 
 pub fn register_instructions() {

--- a/rezasm-source/rezasm-core/src/instructions/implementation/float_arithmetic_instructions.rs
+++ b/rezasm-source/rezasm-core/src/instructions/implementation/float_arithmetic_instructions.rs
@@ -14,112 +14,112 @@ use crate::util::error::SimulatorError;
 use crate::util::raw_data::RawData;
 
 lazy_static! {
-    pub static ref DECF: Instruction =
-        instruction!(decf, |simulator: Simulator,
-                           output: InputOutputTarget| {
-            let value1 = output.get(&simulator)?.float_value();
-            let k = value1 - 1.0;
-            return output.set(simulator, RawData::from_float(k, simulator.get_word_size()));
-        });
-    pub static ref INCF: Instruction =
-        instruction!(incf, |simulator: Simulator,
-                           output: InputOutputTarget| {
-            let value1 = output.get(&simulator)?.float_value();
-            let k = value1 + 1.0;
-            return output.set(simulator, RawData::from_float(k, simulator.get_word_size()));
-        });
-    pub static ref ADDF: Instruction =
-        instruction!(addf, |simulator: Simulator,
-                           output: InputOutputTarget,
-                           input1: InputTarget,
-                           input2: InputTarget| {
-            let value1 = input1.get(&simulator)?.float_value();
-            let value2 = input2.get(&simulator)?.float_value();
-            let k = value1 + value2 ;
-            return output.set(simulator, RawData::from_float(k, simulator.get_word_size()));
-        });
-    pub static ref SUBF: Instruction =
-        instruction!(subf, |simulator: Simulator,
-                           output: InputOutputTarget,
-                           input1: InputTarget,
-                           input2: InputTarget| {
-            let value1 = input1.get(&simulator)?.float_value();
-            let value2 = input2.get(&simulator)?.float_value();
-            let k = value1 - value2 ;
-            return output.set(simulator, RawData::from_float(k, simulator.get_word_size()));
-        });
-    pub static ref MULF: Instruction =
-        instruction!(mulf, |simulator: Simulator,
-                           output: InputOutputTarget,
-                           input1: InputTarget,
-                           input2: InputTarget| {
-            let value1 = input1.get(&simulator)?.float_value();
-            let value2 = input2.get(&simulator)?.float_value();
-            let k = value1 * value2 ;
-            return output.set(simulator, RawData::from_float(k, simulator.get_word_size()));
-        });
-    pub static ref DIVF: Instruction =
-        instruction!(divf, |simulator: Simulator,
-                           output: InputOutputTarget,
-                           input1: InputTarget,
-                           input2: InputTarget| {
-            let value1 = input1.get(&simulator)?.float_value();
-            let value2 = input2.get(&simulator)?.float_value();
-            
-            if value2 == 0f64 {
-                if value1 == 0f64 {
-                    return output.set(simulator, RawData::from_float(NAN, simulator.get_word_size()));
-                }   
-                return Err(SimulatorError::DivideByZeroError);
+pub static ref DECF: Instruction =
+    instruction!(decf, |simulator: Simulator,
+                       output: InputOutputTarget| {
+        let value1 = output.get(&simulator)?.float_value();
+        let k = value1 - 1.0;
+        return output.set(simulator, RawData::from_float(k, simulator.get_word_size()));
+    });
+pub static ref INCF: Instruction =
+    instruction!(incf, |simulator: Simulator,
+                       output: InputOutputTarget| {
+        let value1 = output.get(&simulator)?.float_value();
+        let k = value1 + 1.0;
+        return output.set(simulator, RawData::from_float(k, simulator.get_word_size()));
+    });
+pub static ref ADDF: Instruction =
+    instruction!(addf, |simulator: Simulator,
+                       output: InputOutputTarget,
+                       input1: InputTarget,
+                       input2: InputTarget| {
+        let value1 = input1.get(&simulator)?.float_value();
+        let value2 = input2.get(&simulator)?.float_value();
+        let k = value1 + value2 ;
+        return output.set(simulator, RawData::from_float(k, simulator.get_word_size()));
+    });
+pub static ref SUBF: Instruction =
+    instruction!(subf, |simulator: Simulator,
+                       output: InputOutputTarget,
+                       input1: InputTarget,
+                       input2: InputTarget| {
+        let value1 = input1.get(&simulator)?.float_value();
+        let value2 = input2.get(&simulator)?.float_value();
+        let k = value1 - value2 ;
+        return output.set(simulator, RawData::from_float(k, simulator.get_word_size()));
+    });
+pub static ref MULF: Instruction =
+    instruction!(mulf, |simulator: Simulator,
+                       output: InputOutputTarget,
+                       input1: InputTarget,
+                       input2: InputTarget| {
+        let value1 = input1.get(&simulator)?.float_value();
+        let value2 = input2.get(&simulator)?.float_value();
+        let k = value1 * value2 ;
+        return output.set(simulator, RawData::from_float(k, simulator.get_word_size()));
+    });
+pub static ref DIVF: Instruction =
+    instruction!(divf, |simulator: Simulator,
+                       output: InputOutputTarget,
+                       input1: InputTarget,
+                       input2: InputTarget| {
+        let value1 = input1.get(&simulator)?.float_value();
+        let value2 = input2.get(&simulator)?.float_value();
+
+        if value2 == 0f64 {
+            if value1 == 0f64 {
+                return output.set(simulator, RawData::from_float(NAN, simulator.get_word_size()));
             }
-            let k = value1 / value2 ;
-            return output.set(simulator, RawData::from_float(k, simulator.get_word_size()));
-        });
-    pub static ref MODF: Instruction =
-        instruction!(modf, |simulator: Simulator,
-                           output: InputOutputTarget,
-                           input1: InputTarget,
-                           input2: InputTarget| {
-            let value1 = input1.get(&simulator)?.float_value();
-            let value2 = input2.get(&simulator)?.float_value();
-            
-            if value2 == 0f64 {
-                if value1 == 0f64 {
-                    return output.set(simulator, RawData::from_float(NAN, simulator.get_word_size()));
-                }   
-                return Err(SimulatorError::DivideByZeroError);
+            return Err(SimulatorError::DivideByZeroError);
+        }
+        let k = value1 / value2 ;
+        return output.set(simulator, RawData::from_float(k, simulator.get_word_size()));
+    });
+pub static ref MODF: Instruction =
+    instruction!(modf, |simulator: Simulator,
+                       output: InputOutputTarget,
+                       input1: InputTarget,
+                       input2: InputTarget| {
+        let value1 = input1.get(&simulator)?.float_value();
+        let value2 = input2.get(&simulator)?.float_value();
+
+        if value2 == 0f64 {
+            if value1 == 0f64 {
+                return output.set(simulator, RawData::from_float(NAN, simulator.get_word_size()));
             }
+            return Err(SimulatorError::DivideByZeroError);
+        }
 
-            let divvalue1 = f64::abs(value1);
-            let divvalue2 = f64::abs(value2);
+        let divvalue1 = f64::abs(value1);
+        let divvalue2 = f64::abs(value2);
 
-            let k = divvalue1 - f64::floor(divvalue1/divvalue2) * divvalue2;
+        let k = divvalue1 - f64::floor(divvalue1/divvalue2) * divvalue2;
 
-            return output.set(simulator, RawData::from_float(k, simulator.get_word_size()));
-        });
-    pub static ref ITOF: Instruction =
-        instruction!(itof, |simulator: Simulator,
-                           output: InputOutputTarget,
-                           input1: InputTarget| {
-            let value1 = input1.get(&simulator)?.int_value();
-            
-            let k = value1 as f64;
+        return output.set(simulator, RawData::from_float(k, simulator.get_word_size()));
+    });
+pub static ref ITOF: Instruction =
+    instruction!(itof, |simulator: Simulator,
+                       output: InputOutputTarget,
+                       input1: InputTarget| {
+        let value1 = input1.get(&simulator)?.int_value();
 
-            return output.set(simulator, RawData::from_float(k, simulator.get_word_size()));
-        });
-    pub static ref FTOI: Instruction =
-        instruction!(ftoi, |simulator: Simulator,
-                           output: InputOutputTarget,
-                           input1: InputTarget| {
-            let value1 = input1.get(&simulator)?.float_value();
-            
-            // This has a "feature" due to lack of precision in float representations for some floats... This is
-            // not a particularly fixable thing without getting too complicated.
-            let k = value1 as i64;
+        let k = value1 as f64;
 
-            return output.set(simulator, RawData::from_int(k, simulator.get_word_size()));
-        });
-    }
+        return output.set(simulator, RawData::from_float(k, simulator.get_word_size()));
+    });
+pub static ref FTOI: Instruction =
+    instruction!(ftoi, |simulator: Simulator,
+                       output: InputOutputTarget,
+                       input1: InputTarget| {
+        let value1 = input1.get(&simulator)?.float_value();
+
+        // This has a "feature" due to lack of precision in float representations for some floats... This is
+        // not a particularly fixable thing without getting too complicated.
+        let k = value1 as i64;
+
+        return output.set(simulator, RawData::from_int(k, simulator.get_word_size()));
+    });
+}
 
 pub fn register_instructions() {
     register_instruction(&ADDF);


### PR DESCRIPTION
* Uses better model for shifting which will be consistent over the two different word sizes
* Treats all shift instruction offsets as unsigned integers
* Shifting more bits than there are bits per word on logical shift operations results in the result being 0
* Shifting more bits than there are bits per word on arithmetic shift operations results in the appropriate sign bit filling the result