### PR TITLE
Fix Invalid Labels Not Erroring on "get" Call

### DIFF
--- a/rezasm-source/rezasm-core/src/instructions/targets/input_target.rs
+++ b/rezasm-source/rezasm-core/src/instructions/targets/input_target.rs
@@ -74,9 +74,10 @@ impl Input for InputTarget {
     fn get(&self, simulator: &Simulator) -> Result<RawData, SimulatorError> {
         match self {
             InputTarget::ImmediateInput(x) => Ok(x.clone()),
-            InputTarget::LabelReferenceInput(s) => simulator
-                .get_label_line_number(s)
-                .map(|x| RawData::from_int(x.clone(), simulator.get_word_size())),
+            InputTarget::LabelReferenceInput(s) => {
+                let line = simulator.get_label_line_number(s)?;
+                Ok(RawData::from_int(line, simulator.get_word_size()))
+            },
             InputTarget::StringInput(s) => simulator
                 .get_memory()
                 .get_string_immediate_address(s)


### PR DESCRIPTION
Fixed invalid labels not erroring on "get" call