### PR TITLE
Added NaN conversion check with additional error enumerant

### DIFF
--- a/rezasm-source/rezasm-core/src/instructions/implementation/float_arithmetic_instructions.rs
+++ b/rezasm-source/rezasm-core/src/instructions/implementation/float_arithmetic_instructions.rs
@@ -115,6 +115,10 @@ pub static ref FTOI: Instruction =
 
         // This has a "feature" due to lack of precision in float representations for some floats... This is
         // not a particularly fixable thing without getting too complicated.
+        
+        if value1.is_nan() {
+            return Err(SimulatorError::NaNConversionError);
+        }
         let k = value1 as i64;
 
         return output.set(simulator, RawData::from_int(k, simulator.get_word_size()));

--- a/rezasm-source/rezasm-core/src/instructions/implementation/float_arithmetic_instructions.rs
+++ b/rezasm-source/rezasm-core/src/instructions/implementation/float_arithmetic_instructions.rs
@@ -115,7 +115,7 @@ pub static ref FTOI: Instruction =
 
         // This has a "feature" due to lack of precision in float representations for some floats... This is
         // not a particularly fixable thing without getting too complicated.
-        
+
         if value1.is_nan() {
             return Err(SimulatorError::NaNConversionError);
         }

--- a/rezasm-source/rezasm-core/src/util/error.rs
+++ b/rezasm-source/rezasm-core/src/util/error.rs
@@ -126,7 +126,7 @@ pub enum SimulatorError {
 
     #[error("attempted to divide by zero")]
     DivideByZeroError,
-    
+
     #[error("attempted to convert NaN value to an integer")]
     NaNConversionError,
 }

--- a/rezasm-source/rezasm-core/src/util/error.rs
+++ b/rezasm-source/rezasm-core/src/util/error.rs
@@ -126,6 +126,9 @@ pub enum SimulatorError {
 
     #[error("attempted to divide by zero")]
     DivideByZeroError,
+    
+    #[error("attempted to convert NaN value to an integer")]
+    NaNConversionError,
 }
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
Added an additional enumerant of SimulatorError, NaNConversionError. This error is raised when a user attempts to convert a NaN float arithmetic output into an integer.