### PR TITLE
Sync Requirement for Writer Trait

### DIFF
--- a/rezasm-source/rezasm-core/src/instructions/implementation/terminal_output_instructions.rs
+++ b/rezasm-source/rezasm-core/src/instructions/implementation/terminal_output_instructions.rs
@@ -6,7 +6,7 @@ use crate::instructions::instruction_registry::register_instruction;
 
 use crate::instructions::targets::input_target::Input;
 use crate::instructions::targets::input_target::InputTarget;
-use crate::simulation::writer::WriterGuard;
+use crate::simulation::writer::WriterBox;
 use crate::util::error::IoError;
 
 lazy_static! {
@@ -14,21 +14,21 @@ lazy_static! {
         instruction!(printi, |simulator: Simulator, input: InputTarget| {
             let value = input.get(&simulator)?.int_value();
             let output = format!("{}", value);
-            write(simulator.get_writer(), &output)?;
+            write(simulator.get_writer_mut(), &output)?;
             Ok(())
         });
     pub static ref PRINTF: Instruction =
         instruction!(printf, |simulator: Simulator, input: InputTarget| {
             let value = input.get(&simulator)?.float_value();
             let output = format!("{}", value);
-            write(simulator.get_writer(), &output)?;
+            write(simulator.get_writer_mut(), &output)?;
             Ok(())
         });
     pub static ref PRINTC: Instruction =
         instruction!(printc, |simulator: Simulator, input: InputTarget| {
             let value = input.get(&simulator)?.int_value();
             let output = format!("{}", value as u8 as char);
-            write(simulator.get_writer(), &output)?;
+            write(simulator.get_writer_mut(), &output)?;
             Ok(())
         });
     pub static ref PRINTS_SIZED: Instruction =
@@ -40,19 +40,19 @@ lazy_static! {
             let output = simulator
                 .get_memory()
                 .get_string_sized(address as usize, size as usize)?;
-            write(simulator.get_writer(), &output)?;
+            write(simulator.get_writer_mut(), &output)?;
             Ok(())
         });
     pub static ref PRINTS: Instruction =
         instruction!(prints, |simulator: Simulator, input: InputTarget| {
             let address = input.get(&simulator)?.int_value();
             let output = simulator.get_memory().get_string(address as usize)?;
-            write(simulator.get_writer(), &output)?;
+            write(simulator.get_writer_mut(), &output)?;
             Ok(())
         });
 }
 
-pub fn write(mut writer: WriterGuard, string: &String) -> Result<(), IoError> {
+pub fn write(writer: &mut WriterBox, string: &String) -> Result<(), IoError> {
     writer
         .write(&string.as_bytes())
         .map_err(|t| IoError::StdIoError(t))?;

--- a/rezasm-source/rezasm-core/src/simulation/simulator.rs
+++ b/rezasm-source/rezasm-core/src/simulation/simulator.rs
@@ -6,7 +6,7 @@ use crate::simulation::memory::Memory;
 use crate::simulation::program::Program;
 use crate::simulation::registry;
 use crate::simulation::registry::Registry;
-use crate::simulation::writer::{DummyWriter, Writer, WriterGuard, WriterMutex};
+use crate::simulation::writer::{DummyWriter, Writer, WriterBox};
 use crate::util::error::SimulatorError;
 use crate::util::raw_data::RawData;
 use crate::util::word_size::{WordSize, DEFAULT_WORD_SIZE};
@@ -17,7 +17,7 @@ pub struct Simulator {
     registry: Registry,
     program: Program,
     word_size: WordSize,
-    writer: WriterMutex,
+    writer: WriterBox,
 }
 
 impl Simulator {
@@ -43,7 +43,7 @@ impl Simulator {
             registry: Registry::new(word_size),
             program: Program::new(),
             word_size: word_size.clone(),
-            writer: WriterMutex::new(writer),
+            writer,
         };
         sim.initialize();
         sim
@@ -99,8 +99,8 @@ impl Simulator {
         &self.program
     }
 
-    pub fn get_writer(&self) -> WriterGuard {
-        self.writer.get()
+    pub fn get_writer(&self) -> &WriterBox {
+        &self.writer
     }
 
     pub fn get_word_size_mut(&mut self) -> &mut WordSize {
@@ -117,6 +117,10 @@ impl Simulator {
 
     pub fn get_program_mut(&mut self) -> &mut Program {
         &mut self.program
+    }
+
+    pub fn get_writer_mut(&mut self) -> &mut WriterBox {
+        &mut self.writer
     }
 
     pub fn end_pc(&self) -> usize {

--- a/rezasm-source/rezasm-core/src/simulation/writer.rs
+++ b/rezasm-source/rezasm-core/src/simulation/writer.rs
@@ -2,24 +2,10 @@ use crate::util::as_any::AsAny;
 use std::any::Any;
 use std::fmt::Debug;
 use std::io::Write;
-use std::sync::{Mutex, MutexGuard};
 
-pub trait Writer: Write + AsAny + Send + Debug {}
+pub trait Writer: Write + AsAny + Sync + Send + Debug {}
 
-#[derive(Debug)]
-pub struct WriterMutex(Mutex<Box<dyn Writer>>);
-
-pub type WriterGuard<'a> = MutexGuard<'a, Box<dyn Writer>>;
-
-impl WriterMutex {
-    pub fn new(data: Box<dyn Writer>) -> WriterMutex {
-        WriterMutex(Mutex::new(data))
-    }
-
-    pub fn get(&self) -> WriterGuard {
-        self.0.lock().unwrap()
-    }
-}
+pub type WriterBox = Box<dyn Writer>;
 
 #[derive(Debug)]
 pub struct DummyWriter {}

--- a/rezasm-source/rezasm-web-core/Cargo.toml
+++ b/rezasm-source/rezasm-web-core/Cargo.toml
@@ -18,4 +18,3 @@ rezasm-core = { path = "../rezasm-core" }
 lazy_static = "1.4.0"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.105"
-tokio = { version = "1.32.0", features = ["sync", "rt"] }


### PR DESCRIPTION
* Added `Sync` trait dependency for `Writer` to relieve the need for `WriterMutex`
* `Send` and `Sync` are nearly always auto-derived for any Writer implementation, so this has no negative side effects