### PR TITLE
Added bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Report an issue you found
+title: "[BUG]"
+labels: bug
+assignees: ''
+
+---
+
+**Environment (please complete the following information):**
+ - OS: [e.g. Windows 10, Arch Linux]
+ - Java version: [e.g. 1.17.183]
+ - Program version: [eg. 1.0.1]
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Explain Steps To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
We didn't have one, and we need one. I just took the one from [EzASM](https://github.com/ezasm-org/ezasm/blob/main/.github/ISSUE_TEMPLATE/bug_report.md).