### PR TITLE
Use static OnceLock to store parsed Regex

### DIFF
--- a/rezasm-app/rezasm-wasm/src/lib.rs
+++ b/rezasm-app/rezasm-wasm/src/lib.rs
@@ -5,10 +5,14 @@ extern crate rezasm_web_core;
 extern crate serde_wasm_bindgen;
 extern crate wasm_bindgen;
 
-use rezasm_core::instructions::implementation::register_instructions;
-use rezasm_web_core::{get_exit_status, get_memory_bounds, get_memory_slice, get_register_names, get_register_value, get_register_values, get_word_size, is_completed, load, receive_input, register_writer, reset, step, stop};
-use wasm_bindgen::prelude::*;
 use crate::wasm_writer::WasmWriter;
+use rezasm_core::instructions::implementation::register_instructions;
+use rezasm_web_core::{
+    get_exit_status, get_memory_bounds, get_memory_slice, get_register_names, get_register_value,
+    get_register_values, get_word_size, is_completed, load, receive_input, register_writer, reset,
+    step, stop,
+};
+use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 pub fn wasm_stop() {

--- a/rezasm-source/rezasm-core/src/parser/lexer.rs
+++ b/rezasm-source/rezasm-core/src/parser/lexer.rs
@@ -342,9 +342,12 @@ pub fn is_numeric(token: &String) -> bool {
     static BINARY_PATTERN_CELL: OnceLock<Regex> = OnceLock::new();
     static HEX_PATTERN_CELL: OnceLock<Regex> = OnceLock::new();
     static DECIMAL_PATTERN_CELL: OnceLock<Regex> = OnceLock::new();
-    let binary_pattern = BINARY_PATTERN_CELL.get_or_init(|| Regex::new("^-?0b[10]+\\.?[01]*$").unwrap());
-    let hex_pattern = HEX_PATTERN_CELL.get_or_init(|| Regex::new("^-?0x[\\d|a-f]+\\.?[\\d|a-f]*$").unwrap());
-    let decimal_pattern = DECIMAL_PATTERN_CELL.get_or_init(|| Regex::new("^-?[\\d]+\\.?[\\d]*$").unwrap());
+    let binary_pattern =
+        BINARY_PATTERN_CELL.get_or_init(|| Regex::new("^-?0b[10]+\\.?[01]*$").unwrap());
+    let hex_pattern =
+        HEX_PATTERN_CELL.get_or_init(|| Regex::new("^-?0x[\\d|a-f]+\\.?[\\d|a-f]*$").unwrap());
+    let decimal_pattern =
+        DECIMAL_PATTERN_CELL.get_or_init(|| Regex::new("^-?[\\d]+\\.?[\\d]*$").unwrap());
     let lower = token.to_lowercase();
     binary_pattern.is_match(lower.as_str())
         || hex_pattern.is_match(lower.as_str())
@@ -357,7 +360,7 @@ pub fn tokenize_line(text: &String) -> Vec<String> {
         None => text,
         Some(first) => first,
     }
-        .trim();
+    .trim();
 
     let mut in_single_quotes = false;
     let mut in_double_quotes = false;


### PR DESCRIPTION
* The lexer now uses OneLock to only parse the Regex once
* 10-20x performance speedup in parsing is managed from this
* We should consider trying non-regex matching to see if it can reduce this further