### PR TITLE
Fixed Exit Code Reporting Issue

### DIFF
--- a/src/components/Console.jsx
+++ b/src/components/Console.jsx
@@ -97,7 +97,7 @@ function Console({loaded, registerCallback, exitCode, error}) {
             <div className="console-history-scrollbox" ref={historyScrollbox}>
                 <code className="console-history-text">
                     {consoleHistoryHtml}
-                    {error ? <p className="console-error-text">{error}</p> : <></>}
+                    {error.current ? <p className="console-error-text">{error.current}</p> : <></>}
                 </code>
                 <br/> {/* This is a temporary workaround to an issue where scrolling goes to the second to last element */}
             </div>
@@ -108,7 +108,7 @@ function Console({loaded, registerCallback, exitCode, error}) {
                     className="console-input-text"
                     ref={input}
                     value={inputText}
-                    disabled={error !== ""}
+                    disabled={error.current !== ""}
                     onChange={onInputChange}
                     onKeyDown={onKeyPress}
                 />

--- a/src/components/Controls.jsx
+++ b/src/components/Controls.jsx
@@ -6,7 +6,7 @@ const debounce =
     _.debounce((func) => func(), 250, {leading: true, trailing: false, maxWait: 250});
 
 function Controls({state, setState, start, stop, step, reset, load, error}) {
-    const isErrorState = error !== "";
+    const isErrorState = error.current !== "";
 
     return (
         <div className="mt-2 mb-2 row">
@@ -24,8 +24,8 @@ function Controls({state, setState, start, stop, step, reset, load, error}) {
                     onClick={() => {
                         debounce(() => {
                             reset()
-                                .then(() => load()
-                                    .then(() => start()));
+                                .then(() => load())
+                                .then(() => start());
                         });
                     }}>
                     Start


### PR DESCRIPTION
* Exit codes used to be produced even when errors were printed (i.e., when they were not supposed to)
* The error element of useSimulator is now a useRef to work around timing issues with setError that caused this